### PR TITLE
Split requirements into api.txt and esrgan.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy and install dependencies
-COPY requirements/prod.txt requirements.txt
+COPY requirements/api.txt requirements.txt
 RUN pip install --no-cache-dir grpcio==1.70.0 \
     && pip install --no-cache-dir -r requirements.txt
 
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install dependencies
-COPY requirements/prod.txt requirements.txt
+COPY requirements/api.txt requirements.txt
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile.esrgan
+++ b/Dockerfile.esrgan
@@ -5,8 +5,8 @@ FROM python:3.9-slim AS builder
 # Set working directory
 WORKDIR /app
 
-# Copy only requirements first to leverage Docker cache
-COPY requirements/prod.txt requirements.txt
+# Copy and install ESRGAN-specific dependencies
+COPY requirements/esrgan.txt requirements.txt
 
 # Install build dependencies and Python packages
 # Install only the necessary system packages
@@ -31,6 +31,9 @@ WORKDIR /app
 # Create model directory
 RUN mkdir -p /app/models
 
+# Copy wheels from previous stage
+COPY --from=builder /app/wheels /app/wheels
+
 # Install runtime dependencies
 # Install only the necessary system packages
 # --no-install-recommends reduces image size
@@ -40,9 +43,6 @@ RUN apt-get update \
         libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy wheels from previous stage and install
-COPY --from=builder /app/wheels /app/wheels
-COPY --from=builder /app/requirements.txt .
 # Install Python dependencies
 # Clean pip cache to reduce image size
 RUN pip install --no-cache-dir /app/wheels/* \
@@ -69,4 +69,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 VOLUME /app/models
 
 # Run the application
-CMD ["uvicorn", "esrgan_service.main:app", "--host", "0.0.0.0", "--port", "8001"]
+CMD ["python", "-m", "esrgan_service.main"]

--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -1,0 +1,16 @@
+fastapi==0.109.0
+uvicorn==0.27.0
+python-multipart==0.0.18
+redis==5.0.1
+pillow==10.3.0
+requests==2.32.2
+httpx==0.26.0
+pydantic==2.5.3
+
+# Security fixes for transitive dependencies
+fonttools>=4.43.0
+setuptools>=70.0.0
+urllib3>=2.2.2
+werkzeug>=3.0.6
+wheel>=0.42.0
+zipp>=3.19.1

--- a/requirements/esrgan.txt
+++ b/requirements/esrgan.txt
@@ -1,0 +1,10 @@
+git+https://github.com/xinntao/BasicSR.git
+git+https://github.com/xinntao/Real-ESRGAN.git
+pillow==10.3.0
+torch==2.2.0
+torchvision==0.17.0
+numpy==1.24.3
+
+# Security fixes for transitive dependencies
+setuptools>=70.0.0
+wheel>=0.42.0


### PR DESCRIPTION
This PR splits our requirements into separate files for API and ESRGAN services to:

1. Keep dependencies isolated between services
2. Speed up builds by only installing necessary packages
3. Prevent API from pulling in heavy ML dependencies

Changes:
- Created requirements/api.txt for FastAPI service
- Created requirements/esrgan.txt for ESRGAN service
- Updated Dockerfile to use api.txt
- Updated Dockerfile.esrgan to use esrgan.txt